### PR TITLE
Faster math for users in mainland China

### DIFF
--- a/layout/_partial/plugins/mathjax.ejs
+++ b/layout/_partial/plugins/mathjax.ejs
@@ -18,5 +18,5 @@ MathJax.Hub.Queue(function() {
 });
 </script>
 
-<script async src="//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML" async></script>
+<script async src="//cdn.bootcss.com/mathjax/2.7.0/MathJax.js?config=TeX-MML-AM_CHTML" async></script>
 <% } %>


### PR DESCRIPTION
cdn.mathjax.org is unstable and slow for users in mainland China.Use cdn.bootcss.com for higher speed.